### PR TITLE
(openssh) Use Nano service check only on Nano

### DIFF
--- a/openssh/tools/chocolateyinstall.ps1
+++ b/openssh/tools/chocolateyinstall.ps1
@@ -233,10 +233,15 @@ if ($packageparameters) {
 
 Function CheckServicePath ($ServiceEXE,$FolderToCheck)
 {
-  #The modern way:
-  #Return ([bool]((Get-WmiObject win32_service | ?{$_.Name -ilike "*$ServiceEXE*"} | select -expand PathName) -ilike "*$FolderToCheck*"))
-  #The NANO TP5 Compatible Way:
-  Return ([bool](@(wmic service | ?{$_ -ilike "*$ServiceEXE*"}) -ilike "*$FolderToCheck*"))
+  if ($RunningOnNano) {
+    #The NANO TP5 Compatible Way:
+    Return ([bool](@(wmic service | ?{$_ -ilike "*$ServiceEXE*"}) -ilike "*$FolderToCheck*"))
+  }
+  Else
+  {
+    #The modern way:
+    Return ([bool]((Get-WmiObject win32_service | ?{$_.Name -ilike "*$ServiceEXE*"} | select -expand PathName) -ilike "*$FolderToCheck*"))
+  }
 }
 
 #Extract Files Early

--- a/openssh/tools/chocolateyuninstall.ps1
+++ b/openssh/tools/chocolateyuninstall.ps1
@@ -80,10 +80,15 @@ if ((test-path variable:packageparameters) -AND $packageParameters) {
 
 Function CheckServicePath ($ServiceEXE,$FolderToCheck)
 {
-  #The modern way:
-  #Return ([bool]((Get-WmiObject win32_service | ?{$_.Name -ilike "*$ServiceEXE*"} | select -expand PathName) -ilike "*$FolderToCheck*"))
-  #The NANO TP5 Compatible Way:
-  Return ([bool]((wmic service | ?{$_ -ilike "*$ServiceEXE*"}) -ilike "*$FolderToCheck*"))
+  if ($RunningOnNano) {
+    #The NANO TP5 Compatible Way:
+    Return ([bool](@(wmic service | ?{$_ -ilike "*$ServiceEXE*"}) -ilike "*$FolderToCheck*"))
+  }
+  Else
+  {
+    #The modern way:
+    Return ([bool]((Get-WmiObject win32_service | ?{$_.Name -ilike "*$ServiceEXE*"} | select -expand PathName) -ilike "*$FolderToCheck*"))
+  }
 }
 
 #$SSHServiceInstanceExistsAndIsOurs = ([bool]((Get-WmiObject win32_service | ?{$_.Name -ilike 'sshd'} | select -expand PathName) -ilike "*$TargetFolder*"))


### PR DESCRIPTION
Avoids failure to (un)install on Windows build 17074 and newer. Fixes #56 