### PR TITLE
pwsh 6.2.0

### DIFF
--- a/pwshpackages/powershell-core/powershell-core.nuspec
+++ b/pwshpackages/powershell-core/powershell-core.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>powershell-core</id>
-    <version>6.2.0-rc1</version>
+    <version>6.2.0</version>
     <packageSourceUrl>https://github.com/darwinjs/chocopackages/pwshpackages/powershell-core</packageSourceUrl>
     <owners>DarwinJS</owners>
     <title>powershell-core (Install)</title>
@@ -21,7 +21,7 @@
 
     Preview releases are under the package id powershell-preview so that they can be safely installed and maintained side-by-side with the release versions on production systems.
     Preview versions do not become the default powershell core edition on a system (unless they are the ONLY edition), if you have a preview version installed, access it via pwsh's '-pre' switch.
-    
+
     This package automatically does verbose MSI logging to %temp%\(packagenameandversion).MsiInstall.log
 
     Some helpful install options (any of them can be combined - delimited by space):
@@ -44,7 +44,7 @@
     Removes all powershell core paths before starting install.  Cleans up old paths from old powershell core MSIs.
 
     </description>
-    <releaseNotes>Product Release Notes https://github.com/PowerShell/PowerShell/releases/tag/v6.2.0-rc.1
+    <releaseNotes>Product Release Notes https://github.com/PowerShell/PowerShell/releases/tag/v6.2.0
     Package release Notes:
     6.2.0-rc.1
      - package detects prerelease and displays correct install path in final message, other messaging corrections

--- a/pwshpackages/powershell-core/tools/chocolateyinstall.ps1
+++ b/pwshpackages/powershell-core/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'powershell-core'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$Version = "6.2.0-rc.1"
+$Version = "6.2.0"
 Try {
   [Version]$Version
   $InstallFolder = "$env:ProgramFiles\PowerShell\$($version.split('.')[0])"
@@ -29,9 +29,9 @@ $packageArgs = @{
 
   softwareName  = "PowerShell-6.0.*"
 
-  checksum      = 'DEA825F48A666966B12B08BA224E8EF0BA6BE651DBD1B961193D4B1ECCA3F7F2'
+  checksum      = '99C5F517B5A3B88238C0DFDEF259EA8AB9666C72DA47D093769126C97FF3EE78'
   checksumType  = 'sha256'
-  checksum64    = '0C0F5D68D3C69D36BE4151C3C98BF44F3C6EA33769E19295BE136A785EC10054'
+  checksum64    = 'BF4CBCE14ED448BBAE2DC38293AA637B8C82932893E3804E7711649DFB28E53F'
   checksumType64= 'sha256'
 
   silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`"" # ALLUSERS=1 DISABLEDESKTOPSHORTCUT=1 ADDDESKTOPICON=0 ADDSTARTMENU=0

--- a/pwshpackages/pwsh/pwsh.nuspec
+++ b/pwshpackages/pwsh/pwsh.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>pwsh</id>
-    <version>6.2.0-rc1</version>
+    <version>6.2.0</version>
     <packageSourceUrl>https://github.com/darwinjs/chocopackages/pwshpackages/pwsh</packageSourceUrl>
     <owners>DarwinJS</owners>
     <title>pwsh (Install)</title>
@@ -18,21 +18,21 @@
     <tags>powershell powershell-core pwsh admin</tags>
     <summary>PowerShell Core is the open source multiplatform version of PowerShell.</summary>
     <description>PowerShell Core is the open source multiplatform version of PowerShell
-    
+
     Preview releases are under the package id powershell-preview so that they can be safely installed and maintained side-by-side with the release versions on production systems.
     Preview versions do not become the default powershell core edition on a system (unless they are the ONLY edition), if you have a preview version installed, access it via pwsh's '-pre' switch.
 
     This package automatically does verbose MSI logging to %temp%\(packagenameandversion).MsiInstall.log
 
-    There are some helpful arguments you can pass to the MSI installer, but you should use the powershell-core package 
+    There are some helpful arguments you can pass to the MSI installer, but you should use the powershell-core package
     directly to do so.
 
     </description>
-    <releaseNotes>Product Release Notes https://github.com/PowerShell/PowerShell/releases/tag/v6.2.0-rc.1
+    <releaseNotes>Product Release Notes https://github.com/PowerShell/PowerShell/releases/tag/v6.2.0
     Package release Notes:
-    </releaseNotes>    
+    </releaseNotes>
     <dependencies>
-      <dependency id="powershell-core" version="[6.2.0-rc1]"/>
+      <dependency id="powershell-core" version="[6.2.0]"/>
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
https://devblogs.microsoft.com/powershell/general-availability-of-powershell-core-6-2/

I tested this locally, and it said that since `C:\Program Files\Powershell\6\pwsh.exe` already existed that it didn't need to upgrade, so I don't know if I missed some logic in there, but this may need another change or two before it's released.  Hope it helps!