### PR TITLE
Update paths for powershell-preview

### DIFF
--- a/pwshpackages/powershell-preview/powershell-preview.nuspec
+++ b/pwshpackages/powershell-preview/powershell-preview.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>powershell-preview</id>
-    <version>7.0.0.1</version>
+    <version>7.0.0.20190617</version>
     <packageSourceUrl>https://github.com/darwinjs/chocopackages/pwshpackages/powershell-preview</packageSourceUrl>
     <owners>DarwinJS</owners>
     <title>powershell-preview (Install)</title>

--- a/pwshpackages/powershell-preview/tools/chocolateyinstall.ps1
+++ b/pwshpackages/powershell-preview/tools/chocolateyinstall.ps1
@@ -4,7 +4,7 @@ $ErrorActionPreference = 'Stop';
 $packageName= 'powershell-preview'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $Version = "7.0.0-preview.1"
-$InstallFolder = "$env:ProgramFiles\PowerShell\6-preview"
+$InstallFolder = "$env:ProgramFiles\PowerShell\7-preview"
 
 $packageArgs = @{
   packageName   = $packageName
@@ -31,7 +31,7 @@ if ($pp.CleanUpPath) {
   & "$toolsDir\Reset-PWSHSystemPath.ps1" -PathScope Machine, User -RemoveAllOccurances
 }
 
-If ($PSVersionTable.PSVersion -ilike '6*-preview*')
+If ($PSVersionTable.PSVersion -ilike '7*-preview*')
 {
   Write-Warning "You are running this package under PowerShell core preview, replacing an in-use version may be unpredictable or require multiple attempts."
 }


### PR DESCRIPTION
It seems that after bumping version of `powershell-preview` to `7.0.0-preview.1`, `installFolder` was not updated and it still refers to the old location.

Updating the install folder to `C:\Program Files\PowerShell\7-preview` and the check if the installation is running from 7*-preview version based prompt.