### PR TITLE
Markdown globbing the necessary underscores

### DIFF
--- a/pwshpackages/powershell-core/powershell-core.nuspec
+++ b/pwshpackages/powershell-core/powershell-core.nuspec
@@ -28,16 +28,16 @@
 
     * Any MSI Properties the package responds to can be specified in the same way, even if not documented here.
 
-    --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1"'
+    --install-arguments='"ADD\_EXPLORER\_CONTEXT\_MENU\_OPENPOWERSHELL=1"'
     Installs a right click context menu to start a PowerShell Core prompt for a specific folder.
 
-    --install-arguments='"REGISTER_MANIFEST=1"'
+    --install-arguments='"REGISTER\_MANIFEST=1"'
     Causes PowerShell Core to deliver logs to Windows Event logs.
 
-    --install-arguments='"ENABLE_PSREMOTING=1"'
+    --install-arguments='"ENABLE\_PSREMOTING=1"'
     Enable PS remoting during installation.
 
-    --install-arguments='"ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 REGISTER_MANIFEST=1 ENABLE_PSREMOTING=1"'
+    --install-arguments='"ADD\_EXPLORER\_CONTEXT\_MENU\_OPENPOWERSHELL=1 REGISTER\_MANIFEST=1 ENABLE\_PSREMOTING=1"'
     Do it all.
 
     --packageparameters '"/CleanUpPath"'


### PR DESCRIPTION
Markdown was globbing the necessary underscores of the `--install-arguments`. Took me a while to notice that bug...