### PR TITLE
Correct instructions & Add alternate cmd

### DIFF
--- a/pwshpackages/powershell-preview/tools/chocolateyinstall.ps1
+++ b/pwshpackages/powershell-preview/tools/chocolateyinstall.ps1
@@ -40,11 +40,13 @@ If ($PSVersionTable.PSVersion -ilike '7*-preview*')
 
 Install-ChocolateyPackage @packageArgs
 
+Copy-Item -Path "${InstallFolder}\preview\pwsh-preview.cmd" -Destination "${InstallFolder}\preview\pw7p.cmd"
+
 Write-Output "************************************************************************************"
 Write-Output "*  INSTRUCTIONS: Your system default PowerShell version has not been changed."
 Write-Output "*   PowerShell Core $version, was installed to: `"$installfolder`""
 Write-Output "*   To start PowerShell Core $version, at a prompt or the start menu execute:"
-Write-Output "*      `"pwsh.exe`""
+Write-Output "*      `"pwsh-preview`"  OR  `"pw7p`""
 Write-Output "*   Or start it from the desktop or start menu shortcut installed by this package."
 Write-Output "************************************************************************************"
 


### PR DESCRIPTION
I was very confused when 'pwsh' and 'pwsh.exe' did nothing after I installed this package. I discovered that the installation added `C:\Program Files\PowerShell\7-preview\preview` to my path which only contains a file named pwsh-preview. This is likely so you can run both 6 and 7-preview simultaneously.

Invoking it through `pwsh-preview` feels clumsy. It's not only a bit long, I often confuse when to use a dash and when to use an underscore when I'm trying to remember commands, so I'll often make aliases that have neither.

Unfortunately it seems that this alternate cmd isn't removed when you use `choco uninstall powershell-preview`. I was going to include a 'chocolateyuninstall.ps1' file as part of my PR that addresses this, but I couldn't find a template that represents the default behavior in the documentation.

If you know where I could find such a template, I'll add a 'chocolateyuninstall.ps1' file to my PR. Or, you could do it too, but either way I would like to put it in my notes so I have it at the ready for the next time I submit a PR to a Chocolatey package repo.